### PR TITLE
Fix bug with result base

### DIFF
--- a/lib/aldous/result/base.rb
+++ b/lib/aldous/result/base.rb
@@ -24,12 +24,14 @@ module Aldous
         end
 
         self.class.class_eval do
-          options.each_pair do |key, value|
+          options.each_key do |key|
             next if key.to_s == 'errors' ||
               key.to_s == 'messages' ||
               key.to_s == 'cause' # cause we already have methods for these
+            # do nothing if method is already defined
+            next if instance_methods(false).include?(key.to_sym)
             define_method key do
-              value
+              @_options[key]
             end
           end
         end

--- a/lib/aldous/version.rb
+++ b/lib/aldous/version.rb
@@ -1,3 +1,3 @@
 module Aldous
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
When dynamic methods are defined they should not close over the value
at the time of instantiation, but should read the value from the hash. Also
dynamid methods that have already been defined should not be redefined.
