### PR TITLE
`errors`, always plural, no more singular `error`

### DIFF
--- a/lib/aldous/controller_service/param_present_precondition.rb
+++ b/lib/aldous/controller_service/param_present_precondition.rb
@@ -22,7 +22,7 @@ module Aldous
         end
         Aldous::Result::Success.new
       rescue
-        Aldous::Result::Failure.new(error: "Missing #{required_param_key} param")
+        Aldous::Result::Failure.new(errors: ["Missing #{required_param_key} param"])
       end
     end
   end

--- a/lib/aldous/dispatch/handle_error.rb
+++ b/lib/aldous/dispatch/handle_error.rb
@@ -35,7 +35,7 @@ module Aldous
       end
 
       def result
-        @result ||= ::Aldous::Result::ServerError.new(error: error)
+        @result ||= ::Aldous::Result::ServerError.new(errors: [error])
       end
     end
   end


### PR DESCRIPTION
There's no more code in Aldous that handles `error` as a special attribute, so `error` would be treated as a regular attribute in the result object. So when `errors` is called on the result object, it wouldn't include the value passed in to `error`.
